### PR TITLE
Add *.test.jsx to frontend test list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/swsnu/swpp2019-team20.svg?branch=master)](https://travis-ci.org/swsnu/swpp2019-team20)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=swsnu_swpp2019-team20&metric=alert_status)](https://sonarcloud.io/dashboard?id=swsnu_swpp2019-team20)
-[![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2019-team20/badge.svg)](https://coveralls.io/github/swsnu/swpp2019-team20)
+[![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2019-team20/badge.svg?branch=master)](https://coveralls.io/github/swsnu/swpp2019-team20?branch=master)
 
 ![logo](./frontend/src/logo.png)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.sources=backend,frontend/src
 sonar.tests=backend,frontend/src
 
 sonar.exclusions=backend/**/migrations/*,frontend/src/index.js,frontend/src/serviceWorker.js
-sonar.test.inclusions=backend/**/tests.py,frontend/src/**/*.test.js
+sonar.test.inclusions=backend/**/tests.py,frontend/src/**/*.test.js,frontend/src/**/*.test.jsx
 
 sonar.python.coverage.reportPaths=backend/coverage.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
I think this should make sonarcloud exclude these from the coverage report, since it makes little sense for it to track coverage for test files.

Closes #44.