### PR TITLE
Change profile page url

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import IndexPage from './pages/IndexPage/IndexPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import SignupPage from './pages/SignupPage/SignupPage';
@@ -15,9 +15,19 @@ function App() {
     loggedIn: false,
     username: '',
   });
+  const [userID, setUserID ] = useState(0);
 
-  function onLoggedIn() {
+  function onLoggedIn() {   //set if current user is logged in
     setUser({ loggedIn: true, username: '' });
+  }
+
+  async function getID() {  //set current user(logged in)'s ID
+    const res = await fetch('/account/user/me', {
+      method: 'GET',
+      credential: 'include',
+    });
+    const info = await res.json();
+    setUserID(info.id);
   }
 
   const getLogin = async () => {
@@ -27,6 +37,7 @@ function App() {
     });
 
     if (response.status === 204) {
+      await getID();
       onLoggedIn();
     }
   };
@@ -37,7 +48,8 @@ function App() {
 
   const router = user.loggedIn ? (
     <Switch>
-      <Route path="/profile" exact component={ProfilePage} />
+      <Route path="/profile/:userID" exact component={ProfilePage} />
+      <Redirect exact from='/profile' to={`/profile/${userID}`} />
       <Route path="/main" exact component={MainPage} />
       {/* eslint-disable-next-line */}
       <Route exact path="/" exact component={MainPage} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
+import {
+  BrowserRouter, Route, Redirect, Switch,
+} from 'react-router-dom';
 import IndexPage from './pages/IndexPage/IndexPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import SignupPage from './pages/SignupPage/SignupPage';
@@ -15,13 +17,13 @@ function App() {
     loggedIn: false,
     username: '',
   });
-  const [userID, setUserID ] = useState(0);
+  const [userID, setUserID] = useState(0);
 
-  function onLoggedIn() {   //set if current user is logged in
+  function onLoggedIn() { // set if current user is logged in
     setUser({ loggedIn: true, username: '' });
   }
 
-  async function getID() {  //set current user(logged in)'s ID
+  async function getID() { // set current user(logged in)'s ID
     const res = await fetch('/account/user/me', {
       method: 'GET',
       credential: 'include',
@@ -49,7 +51,7 @@ function App() {
   const router = user.loggedIn ? (
     <Switch>
       <Route path="/profile/:userID" exact component={ProfilePage} />
-      <Redirect exact from='/profile' to={`/profile/${userID}`} />
+      <Redirect exact from="/profile" to={`/profile/${userID}`} />
       <Route path="/main" exact component={MainPage} />
       {/* eslint-disable-next-line */}
       <Route exact path="/" exact component={MainPage} />

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -19,22 +19,11 @@ describe('<App />', () => {
   // eslint-disable-next-line
   let getLoginSpy;
 
-  beforeEach(() => {
-    getLoginSpy = jest.spyOn(window, 'fetch')
-      // eslint-disable-next-line
-      .mockImplementation((url) => {
-        const result = {
-          status: 204,
-        };
-        return Promise.resolve(result);
-      });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('when loggedIn is true', () => {
+  test('when loggedIn is false', () => {
     getLoginSpy = jest.spyOn(window, 'fetch')
       // eslint-disable-next-line
       .mockImplementation((url) => {
@@ -57,7 +46,16 @@ describe('<App />', () => {
     expect(component.length).toBe(1);
   });
 
-  test('when loggedIn is false', () => {
+  test('when loggedIn is true', () => {
+    getLoginSpy = jest.spyOn(window, 'fetch')
+      // eslint-disable-next-line
+      .mockImplementation((url) => {
+        const result = {
+          status: 204,
+        };
+        return Promise.resolve(result);
+      });
+
     const [user, setUser] = useStateSpy({
       loggedIn: false,
       username: '',
@@ -69,5 +67,28 @@ describe('<App />', () => {
       </AppContext.Provider>,
     );
     expect(component.length).toBe(1);
+  });
+
+  test('redirect profile page', () => {
+    getLoginSpy = jest.spyOn(window, 'fetch')
+      // eslint-disable-next-line
+      .mockImplementation((url) => {
+        const result = {
+          status: 204,
+          json: () => ({ id: 7 }),
+        };
+        return Promise.resolve(result);
+      });
+
+    const [user, setUser] = useStateSpy({
+      loggedIn: false,
+      username: '',
+    });
+
+    mount(
+      <AppContext.Provider value={{ user, setUser }}>
+        <App />
+      </AppContext.Provider>,
+    );
   });
 });

--- a/frontend/src/pages/MainPage/TransactionList/container.jsx
+++ b/frontend/src/pages/MainPage/TransactionList/container.jsx
@@ -55,6 +55,7 @@ const TransactionList = (props) => {
       body: JSON.stringify(content), // body data type must match "Content-Type" header
     });
 
+    // eslint-disable-next-line
     if (response.status === 403) alert('not your transaction! ;_;');
     else {
       setBtnDisabled(true);

--- a/frontend/src/pages/ProfilePage/Profile/container.jsx
+++ b/frontend/src/pages/ProfilePage/Profile/container.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router'
+import { useParams } from 'react-router';
 import Presenter from './presenter';
 
 const Profile = () => {

--- a/frontend/src/pages/ProfilePage/Profile/container.jsx
+++ b/frontend/src/pages/ProfilePage/Profile/container.jsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router'
 import Presenter from './presenter';
 
 const Profile = () => {
   const [isLoading, setLoading] = useState(true);
   const [userInfo, setUserInfo] = useState('');
 
-  const targetUrl = '/account/user/me';
+  const { userID } = useParams();
+
+  const targetUrl = `/account/user/${userID}`;
   const fetchProfile = async () => {
     const res = await fetch(targetUrl, {
       method: 'GET',

--- a/frontend/src/pages/ProfilePage/Profile/container.test.jsx
+++ b/frontend/src/pages/ProfilePage/Profile/container.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { BrowserRouter } from 'react-router-dom';
 import Profile from './container';
 
 describe('Profile', () => {
@@ -12,13 +13,24 @@ describe('Profile', () => {
       id: 1,
     }
   );
+  let profile;
+
+  beforeEach(() => {
+    profile = (
+      <BrowserRouter>
+        <Profile />
+      </BrowserRouter>
+    );
+  });
+
   test('renders without errors', () => {
-    const component = shallow(<Profile />);
+    const component = mount(profile);
     expect(component.length).toEqual(1);
   });
+
   it('works with fetch', async () => {
     const mockFn = jest.spyOn(window, 'fetch').mockImplementation(() => ({ json: () => request }));
-    mount(<Profile />);
+    mount(profile);
     expect(mockFn).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #105 

/profile/:(id)
  opens the profile page of a user whose ID is (:id)
/profile
  redirects to /profile/:(user_id)

Profile page of current user and that of other people have same components.

----

/profile/:(id)
  ID 가 (:id)인 유저의 프로필 페이지를 열음
/profile
  /profile/:(현재 로그인한 유저의 ID) 로 redirect함

현재 로그인한 유저의 프로필 페이지와 다른 사람의 프로필 페이지는 동일한 컴포넌트들을 가지고 있음